### PR TITLE
feat(ui): add global error handling and notifications

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,28 @@
 import AppLayout from '@/components/layout/AppLayout.vue';
 import { RouterView } from 'vue-router';
 import ReloadPrompt from '@/components/layout/ReloadPrompt.vue';
+import ToastNotification from '@/components/ui/ToastNotification.vue';
+import { onErrorCaptured } from 'vue';
+import { useNotificationStore } from '@/stores/notifications';
+
+const notificationStore = useNotificationStore();
+
+onErrorCaptured((err) => {
+  console.error('Captured Error:', err);
+  notificationStore.addNotification({
+    message: 'An unexpected error occurred. Please try again.',
+    type: 'error',
+    duration: 5000
+  });
+  return false; // Prevent error from propagating further if handled
+});
 </script>
 
 <template>
   <AppLayout>
     <RouterView />
     <ReloadPrompt />
+    <ToastNotification />
   </AppLayout>
 
 </template>

--- a/src/components/ui/ToastNotification.vue
+++ b/src/components/ui/ToastNotification.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { useNotificationStore } from '@/stores/notifications';
+import { storeToRefs } from 'pinia';
+
+const store = useNotificationStore();
+const { notifications } = storeToRefs(store);
+const { removeNotification } = store;
+
+function getTypeClass(type: string) {
+  switch (type) {
+    case 'success': return 'toast-success';
+    case 'error': return 'toast-error';
+    case 'warning': return 'toast-warning';
+    default: return 'toast-info';
+  }
+}
+</script>
+
+<template>
+  <div class="toast-container">
+    <transition-group name="toast">
+      <div 
+        v-for="notification in notifications" 
+        :key="notification.id"
+        class="toast-message"
+        :class="getTypeClass(notification.type)"
+      >
+        <span>{{ notification.message }}</span>
+        <button @click="removeNotification(notification.id)" class="close-btn">×</button>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.toast-message {
+  padding: 12px 20px;
+  border-radius: 4px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 250px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+.toast-info { background-color: #2196F3; }
+.toast-success { background-color: #4CAF50; }
+.toast-warning { background-color: #FF9800; }
+.toast-error { background-color: #F44336; }
+
+.close-btn {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 20px;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.3s ease;
+}
+
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+</style>

--- a/src/stores/notifications.ts
+++ b/src/stores/notifications.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export interface Notification {
+    id: string;
+    message: string;
+    type: 'info' | 'success' | 'warning' | 'error';
+    duration?: number;
+}
+
+export const useNotificationStore = defineStore('notifications', () => {
+    const notifications = ref<Notification[]>([]);
+
+    function addNotification(notification: Omit<Notification, 'id'>) {
+        const id = Date.now().toString();
+        const newNotification = { ...notification, id };
+        notifications.value.push(newNotification);
+
+        if (notification.duration !== 0) {
+            setTimeout(() => {
+                removeNotification(id);
+            }, notification.duration || 3000);
+        }
+    }
+
+    function removeNotification(id: string) {
+        const index = notifications.value.findIndex(n => n.id === id);
+        if (index !== -1) {
+            notifications.value.splice(index, 1);
+        }
+    }
+
+    return {
+        notifications,
+        addNotification,
+        removeNotification
+    };
+});


### PR DESCRIPTION
Implement notification store and Toast component. Add global error handler in App.vue to capture and display errors. Fixes #55.