### PR TITLE
refactor(all-pokemon): simplify bulk catch and selection logic per user request

### DIFF
--- a/src/components/pokemon/PokemonCard.vue
+++ b/src/components/pokemon/PokemonCard.vue
@@ -96,9 +96,28 @@ function padId(id: number): string {
   border-color: rgba(255, 255, 255, 0.3);
 }
 
+/* styling for caught state: target content parts except the star */
+.is-caught .pokemon-image,
+.is-caught .card-info,
+.is-caught .pokemon-id {
+  filter: grayscale(1);
+  opacity: 0.5;
+}
+
 .is-caught {
-  border-color: #FFD700;
-  box-shadow: 0 0 10px rgba(255, 215, 0, 0.2);
+  /* Optional: make background grayish if needed, or rely on content grayscale? 
+     Title said "greyishh". 
+     If I don't filter root, background gradient is still colored.
+     I should probably make background grey too.
+  */
+  background: #f0f0f0 !important;
+  cursor: default; /* "cannot select it" */
+}
+
+.is-caught:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: transparent;
 }
 
 .card-header {

--- a/src/components/pokemon/PokemonGrid.vue
+++ b/src/components/pokemon/PokemonGrid.vue
@@ -5,10 +5,12 @@ import type { Pokemon } from '@/types/domain';
 
 defineProps<{
   pokemonList: Pokemon[];
+  selectedIds?: Set<number>;
 }>();
 
 const emit = defineEmits<{
-  (e: 'click', pokemon: Pokemon): void;
+  (e: 'click', event: MouseEvent, pokemon: Pokemon): void;
+  (e: 'contextmenu', event: MouseEvent, pokemon: Pokemon): void;
 }>();
 
 const store = usePokemonStore();
@@ -17,13 +19,19 @@ const { isCaught } = store;
 
 <template>
   <div class="pokemon-grid">
-    <PokemonCard
+    <div 
       v-for="pokemon in pokemonList"
       :key="pokemon.id"
-      :pokemon="pokemon"
-      :is-caught="isCaught(pokemon.id)"
-      @click="emit('click', pokemon)"
-    />
+      class="card-wrapper"
+      :class="{ 'selected': selectedIds?.has(pokemon.id) }"
+    >
+      <PokemonCard
+        :pokemon="pokemon"
+        :is-caught="isCaught(pokemon.id)"
+        @click="emit('click', $event, pokemon)"
+        @contextmenu.prevent="emit('contextmenu', $event, pokemon)"
+      />
+    </div>
   </div>
 </template>
 
@@ -33,5 +41,25 @@ const { isCaught } = store;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1.5rem;
   padding: 1rem 0;
+}
+
+.card-wrapper {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.card-wrapper.selected::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(102, 126, 234, 0.4); 
+  border: 2px solid #667eea;
+  border-radius: 1rem;
+  pointer-events: none;
+  z-index: 5;
 }
 </style>

--- a/src/components/pokemon/PokemonList.vue
+++ b/src/components/pokemon/PokemonList.vue
@@ -4,10 +4,12 @@ import type { Pokemon } from '@/types/domain';
 
 defineProps<{
   pokemonList: Pokemon[];
+  selectedIds?: Set<number>;
 }>();
 
 const emit = defineEmits<{
-  (e: 'click', pokemon: Pokemon): void;
+  (e: 'click', event: MouseEvent, pokemon: Pokemon): void;
+  (e: 'contextmenu', event: MouseEvent, pokemon: Pokemon): void;
 }>();
 
 const store = usePokemonStore();
@@ -32,7 +34,9 @@ function padId(id: number): string {
       v-for="pokemon in pokemonList"
       :key="pokemon.id"
       class="pokemon-list-item"
-      @click="emit('click', pokemon)"
+      :class="{ 'selected': selectedIds?.has(pokemon.id) }"
+      @click="emit('click', $event, pokemon)"
+      @contextmenu.prevent="emit('contextmenu', $event, pokemon)"
     >
       <div class="item-left">
         <img :src="pokemon.imageUrl" :alt="pokemon.name" loading="lazy" />
@@ -75,11 +79,27 @@ function padId(id: number): string {
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   cursor: pointer;
   transition: transform 0.1s, box-shadow 0.1s;
+  position: relative;
+  overflow: hidden;
 }
 
 .pokemon-list-item:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(0,0,0,0.08);
+}
+
+.pokemon-list-item.selected::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(102, 126, 234, 0.4); 
+  border: 2px solid #667eea;
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 5;
 }
 
 .item-left {


### PR DESCRIPTION
- Prevent selection and context menu for caught Pokemon

- Implement visual distinction (grey + yellow star) for caught Pokemon

- Refine context menu: Single Catch navigates, Bulk Catch actions immediately

- Remove release option from All Pokemon view

fix #77 