### PR TITLE
fix: Single click now exclusively selects one Pokemon

### DIFF
--- a/src/views/AllPokemonView.vue
+++ b/src/views/AllPokemonView.vue
@@ -87,19 +87,25 @@ onUnmounted(() => {
   document.removeEventListener('click', closeContextMenu);
 });
 
-function handlePokemonClick(_event: MouseEvent | any, pokemon: Pokemon) {
+function handlePokemonClick(event: MouseEvent | any, pokemon: Pokemon) {
   if (contextMenuVisible.value) closeContextMenu();
 
   // Prevent selecting caught pokemon
   if (isCaught(pokemon.id)) return;
 
-  // Pure Selection Logic - Toggle
-  if (selectedIds.value.has(pokemon.id)) {
-    selectedIds.value.delete(pokemon.id);
+  // Check for Ctrl/Meta key for multi-select
+  if (event.ctrlKey || event.metaKey) {
+    // Toggle selection
+    if (selectedIds.value.has(pokemon.id)) {
+      selectedIds.value.delete(pokemon.id);
+    } else {
+      selectedIds.value.add(pokemon.id);
+    }
+    selectedIds.value = new Set(selectedIds.value); // Trigger reactivity
   } else {
-    selectedIds.value.add(pokemon.id);
+    // Single click: exclusively select this Pokemon
+    selectedIds.value = new Set([pokemon.id]);
   }
-  selectedIds.value = new Set(selectedIds.value); // Trigger reactivity
 }
 
 function handleRightClick(event: MouseEvent | TouchEvent, pokemon: Pokemon) {

--- a/src/views/MyPokedexView.vue
+++ b/src/views/MyPokedexView.vue
@@ -85,11 +85,8 @@ function handleCardClick(event: MouseEvent, id: number) {
   if (event.ctrlKey || event.metaKey) {
     toggleSelection(id);
   } else {
-    // Normal click now JUST selects (or clears and selects)
-    // Removed the "else -> Single release" logic
-    selectedIds.value.clear();
-    selectedIds.value.add(id);
-    selectedIds.value = new Set(selectedIds.value);
+    // Exclusive selection: Clear everything else, select ONLY this one
+    selectedIds.value = new Set([id]);
     selectMode.value = true;
   }
 }


### PR DESCRIPTION
- Fixed AllPokemonView: Normal click selects only clicked Pokemon
- Fixed MyPokedexView: Same exclusive selection behavior
- Ctrl+Click multi-select behavior preserved in both views
- Right-click context menu behavior unchanged

fix #102 